### PR TITLE
Smart double equals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 2.1.0 - 06-01-17
+### Changed
+ - Turned on "smart" mode for [eqeqeq](http://eslint.org/docs/rules/eqeqeq).
+
 ## 2.0.1 - 05-04-17
 ### Changed
  - Missed changelog updates.

--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ Any benefits of omitting curly braces is surely outweighed by the potential for 
 #### [eqeqeq](http://eslint.org/docs/rules/eqeqeq)
 The `==` and `!=` operators use type coercion which [may not behave as expected](http://www.ecma-international.org/ecma-262/5.1/#sec-11.9.3).
 Be explicit and use `===` and `!==` instead.
+The [smart](http://eslint.org/docs/rules/eqeqeq#smart) option for this rule is enabled.
 
 #### [no-alert](http://eslint.org/docs/rules/no-alert)
 The default `alert`, `confirm`, and `prompt` UI elements will block the event loop (not to mention they are horrid).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-spreetail",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "description": "ESLint configuration used at Spreetail.",
   "main": "index.js",
   "scripts": {

--- a/rules/best-practices.js
+++ b/rules/best-practices.js
@@ -4,7 +4,7 @@ var rules = {
     'consistent-return': 'warn',
     'curly': 'error',
     'default-case': 'error',
-    'eqeqeq': 'error',
+    'eqeqeq': ['error', 'smart'],
     'no-alert': 'error',
     'no-caller': 'error',
     'no-case-declarations': 'error',


### PR DESCRIPTION
Sets the [smart](http://eslint.org/docs/rules/eqeqeq#smart) option for the eqeqeq rule and bumps the version to 2.1.0