### PR TITLE
FEND-434: Fix experimentalObjectRestSpread deprecation warning

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,10 +7,10 @@ module.exports = {
     es6: true,
   },
   parserOptions: {
+    ecmaVersion: 2018,
     ecmaFeatures: {
-      jsx: true,
-      experimentalObjectRestSpread: true,
-    },
+      jsx: true
+    }
   },
   settings: {
     react: {


### PR DESCRIPTION
What changed:

- Removed experimentalObjectRestSpread: true from ecmaFeatures property
- Added ecmaVersion: 2018 to parserOptions property

How to test:

- Set project to use eslint version 5.0.0 or higher
- Run project
- Check for deprecation warnings. 